### PR TITLE
Issue #64: Bump required "catalog" version to 0.13.0-alpha

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,10 @@
     ],
     "require": {
         "php": "^7.0.0",
-        "lizards-and-pumpkins/catalog": "^0.12.0-alpha"
+        "lizards-and-pumpkins/catalog": "^0.13.0-alpha"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.4",
+        "phpunit/phpunit": "^5.6.2",
         "lizards-and-pumpkins/coding-standards": "dev-master"
     },
     "autoload": {


### PR DESCRIPTION
Close #64.